### PR TITLE
Add rollback condition on failing to parse proper syntax

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,7 +83,7 @@ impl Statement {
                     // Incase the user forgets to input required options
                     // for an operation, fail by setting None.
                     eprintln!(
-                        "Error: Operation `{}` was ignored, KEY not provided.",
+                        "Error: `{}` operation ignored, KEY not provided.",
                         stype.get_word()
                     );
                     None
@@ -104,7 +104,7 @@ impl Statement {
                     // Incase the user forgets to input required options
                     // for an operation, fail by setting None.
                     eprintln!(
-                        "Error: Operation `{}` was ignored, VALUE not provided.",
+                        "Error: `{}` operation ignored, VALUE not provided.",
                         stype.get_word()
                     );
                     None

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -23,9 +23,11 @@ pub enum StatementType {
     Get,
     /// Relates to the rem() method of the Storage Engine.
     Rem,
-    /// The parser has failed to understand what the user 
-    /// wants to do, No such operation exists.
-    Unrecognized,
+    /// No such operation exists.
+    Unk,
+    /// The parser has failed to understand what the user wants 
+    /// to do. Parsing has failed due to wrong command syntax.
+    Fail,
 }
 
 impl StatementType {
@@ -35,7 +37,16 @@ impl StatementType {
             "set" | "put" | "insert" | "i" => Self::Set,
             "get" | "select" | "o" => Self::Get,
             "rem" | "remove" | "del" | "delete" | "rm" => Self::Rem,
-            _ => Self::Unrecognized,
+            _ => Self::Unk,
+        }
+    }
+
+    fn get_word(&self) -> String {
+        match self {
+            Self::Set => "SET".to_string(),
+            Self::Get => "GET".to_string(),
+            Self::Rem => "REM".to_string(),
+            _ => "Unknown".to_string(),
         }
     }
 }
@@ -64,33 +75,59 @@ impl Statement {
             false => "".to_string(),
         };
 
-        Self {
-            key: match stype {
-                StatementType::Get | StatementType::Set | StatementType::Rem => {
-                    // The first word after the operation keyword is supposed to be
-                    // the statement key, else the statement has failed to parse.
-                    // TODO: Figure out how to backout of execution and fail.
+        // The first word after the operation keyword is supposed to be
+        // the statement key, else the statement has failed to parse.
+        let key = match stype {
+            StatementType::Get | StatementType::Set | StatementType::Rem => {
+                if cmd_words.len() < 1 {
+                    // Incase the user forgets to input required options
+                    // for an operation, fail by setting None.
+                    eprintln!(
+                        "Error: Operation `{}` was ignored, KEY not provided.",
+                        stype.get_word()
+                    );
+                    None
+                } else {
                     Some(cmd_words[1].to_string())
                 }
-                _ => None,
-            },
-            value: match stype {
-                StatementType::Set => {
-                    // The string after the operation keyword and the statement key
-                    // is the statement value. Parsing should fail if no such value
-                    // for the `set` operation. Currently, the code sets value to an
-                    // empty string value. TODO: Figure out how to backout and fail.
-                    Some(cmd_val)
-                },
-                _ => {
-                    if cmd_words.len() > 2 {
-                        // Incase the user passes in too much data for an operation, warn them.
-                        eprintln!("Warning: Too many inputs, `{}` was ignored.", cmd_val);
-                    }
+            }
+            _ => None,
+        };
+
+        // The string after the operation keyword and the statement key
+        // is the statement value. Parsing should fail if no such value
+        // for the `set` operation. Currently, the code sets value to an
+        // empty string value.
+        let value = match stype {
+            StatementType::Set => {
+                if cmd_words.len() < 2 {
+                    // Incase the user forgets to input required options
+                    // for an operation, fail by setting None.
+                    eprintln!(
+                        "Error: Operation `{}` was ignored, VALUE not provided.",
+                        stype.get_word()
+                    );
                     None
+                } else {
+                    Some(cmd_val)
                 }
-            },
-            stype,
+            }
+            _ => {
+                if cmd_words.len() > 2 {
+                    // Incase the user passes in too much data for an operation, warn them.
+                    eprintln!("Warning: Too many inputs, `{}` was ignored.", cmd_val);
+                }
+                None
+            }
+        };
+
+        // Quick Fix to #1. If for most operations key is set to None and for set operation only, 
+        // if value is set to None, set stype to Fail to fail parsing.
+        if !(stype == StatementType::Set && value.is_some()) && key.is_some() {
+            Self { stype, key, value }
+        } else {
+            // Fail state, when user forgets to pass necessary inputs.
+            Self { stype: StatementType::Fail, key: None, value: None }
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -25,7 +25,7 @@ pub enum StatementType {
     Rem,
     /// No such operation exists.
     Unk,
-    /// The parser has failed to understand what the user wants 
+    /// The parser has failed to understand what the user wants
     /// to do. Parsing has failed due to wrong command syntax.
     Fail,
 }
@@ -79,7 +79,7 @@ impl Statement {
         // the statement key, else the statement has failed to parse.
         let key = match stype {
             StatementType::Get | StatementType::Set | StatementType::Rem => {
-                if cmd_words.len() < 1 {
+                if cmd_words.len() < 2 {
                     // Incase the user forgets to input required options
                     // for an operation, fail by setting None.
                     eprintln!(
@@ -100,7 +100,7 @@ impl Statement {
         // empty string value.
         let value = match stype {
             StatementType::Set => {
-                if cmd_words.len() < 2 {
+                if cmd_words.len() < 3 {
                     // Incase the user forgets to input required options
                     // for an operation, fail by setting None.
                     eprintln!(
@@ -121,13 +121,17 @@ impl Statement {
             }
         };
 
-        // Quick Fix to #1. If for most operations key is set to None and for set operation only, 
+        // Quick Fix to #1. If for most operations key is set to None and for set operation only,
         // if value is set to None, set stype to Fail to fail parsing.
-        if !(stype == StatementType::Set && value.is_some()) && key.is_some() {
+        if !(stype == StatementType::Set && value.is_none()) && key.is_some() {
             Self { stype, key, value }
         } else {
             // Fail state, when user forgets to pass necessary inputs.
-            Self { stype: StatementType::Fail, key: None, value: None }
+            Self {
+                stype: StatementType::Fail,
+                key: None,
+                value: None,
+            }
         }
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -74,10 +74,11 @@ impl REPL {
                     }
                 },
                 StatementType::Rem => self.store.rem(key),
-                StatementType::Unrecognized => {
+                StatementType::Unk => {
                     println!("db: command not found: {}", self.cmd);
                     ExecResult::Failed
-                }
+                },
+                StatementType::Fail => ExecResult::Failed,
             } {
                 ExecResult::Failed => eprintln!("Command Execution Failed."),
                 ExecResult::Success => println!("Success: OK"),

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -54,12 +54,12 @@ impl REPL {
             }
         } else {
             let st = Statement::prep(&self.cmd);
-            let key = st.key.unwrap();
+            let key = st.key.unwrap_or("".to_string());
             // If type of statement is legit, execute, else fail.
             match match st.stype {
                 StatementType::Set => self.store.set(key, st.value.unwrap()),
                 StatementType::Get => {
-                    match self.store.get(key) {
+                    match self.store.get(key.clone()) {
                         Ok(res) => {
                             println!("{}", res);
                             ExecResult::Success
@@ -67,7 +67,7 @@ impl REPL {
                         Err(ExecResult::Failed) => {
                             // If the key doesn't exist, get() explicitly returns this,
                             // so print the desired Error message.
-                            eprintln!("Error: No value associated with key `{}`.", *key);
+                            eprintln!("Error: No value associated with key `{}`.", key);
                             ExecResult::Failed
                         },
                         _ => ExecResult::Failed,

--- a/src/store.rs
+++ b/src/store.rs
@@ -23,19 +23,16 @@ impl Store {
     /// Operates HashMap::insert()
     pub fn set(&mut self, key: String, value: String) -> ExecResult {
         // Fails if key already points to another value, else stores key-value pair and returns success.
-        match self.storage.contains_key(&key) {
-            true => {
-                eprintln!(
-                    "Error: `{}` already associated with value `{}`.",
-                    self.storage.get(&key).unwrap(),
-                    key
-                );
-                ExecResult::Failed
-            }
-            _ => {
-                self.storage.insert(key, value);
-                ExecResult::Success
-            }
+        if self.storage.contains_key(&key) {
+            eprintln!(
+                "Error: `{}` already associated with value `{}`.",
+                self.storage.get(&key).unwrap(),
+                key
+            );
+            ExecResult::Failed
+        } else {
+            self.storage.insert(key, value);
+            ExecResult::Success
         }
     }
 
@@ -44,7 +41,7 @@ impl Store {
     pub fn get(&self, key: String) -> Result<String, ExecResult> {
         match self.storage.get(&key) {
             None => Err(ExecResult::Failed),
-            Some(s) => Ok(s.to_string())
+            Some(s) => Ok(s.to_string()),
         }
     }
 


### PR DESCRIPTION
Fixes: #1 

#### Changes
- Add special enum symbol to denote failed parse.
- Add code to trigger failed parse condition.
- Create flow to smoothly rollback statement creation, avoiding further execution of wrong syntax code.